### PR TITLE
Updating lymbix python wrapper

### DIFF
--- a/lymbix.py
+++ b/lymbix.py
@@ -3,138 +3,138 @@ import urllib2
 import json
 
 class Lymbix:
-  
-  API_BASE = 'https://gyrus.lymbix.com/';
-  TONALIZE_MULTIPLE = 'tonalize_multiple';
-  TONALIZE_DETAILED = 'tonalize_detailed';
-  TONALIZE = 'tonalize';
-  FLAG_RESPONSE = 'flag_response';
+    
+    API_BASE = 'https://gyrus.lymbix.com/';
+    TONALIZE_MULTIPLE = 'tonalize_multiple';
+    TONALIZE_DETAILED = 'tonalize_detailed';
+    TONALIZE = 'tonalize';
+    FLAG_RESPONSE = 'flag_response';
 
-  def __init__(self, authentication_key):
-    '''
-    Args:
-        -authentication_key: your Lymbix authentication key
-    '''
-    if authentication_key == None or len(authentication_key) == 0:
-      raise Exception('You must include your authentication key')
-    
-    self.authentication_key = authentication_key
-  
-  ''' utility functions '''
-  
-  def _get_headers(self):
-    headers = {
-      'Authentication': self.authentication_key,
-      'Accept': 'application/json',
-      'Version': '2.2'}
-    return headers
-  
-  ''' api methods '''
-  
-  def tonalize_multiple(self, articles, options = None):
-    '''
-    tonalize multiple articles
-    
-    Args:
-        -articles: articles to tonalize
-        -options: additional parameters (reference_ids and return_fields)
+    def __init__(self, authentication_key):
+        '''
+        Args:
+                -authentication_key: your Lymbix authentication key
+        '''
+        if authentication_key == None or len(authentication_key) == 0:
+            raise Exception('You must include your authentication key')
         
-    Returns:
-        -see the api documentation for the format of this object
-    '''
-    if articles == None or len(articles) == 0:
-      raise Exception('You must include articles to tonalize')
-  
-    url = self.API_BASE + self.TONALIZE_MULTIPLE
-    data = {'articles': articles}
-    if options != None: data.update(options)
-    for key, value in data.iteritems(): data[key] = json.dumps(value)
-    data = urllib.urlencode(data)
+        self.authentication_key = authentication_key
     
-    headers = self._get_headers()
-    request = urllib2.Request(url, data, headers)
-    response = urllib2.urlopen(request)
-    return json.loads(response.read())
+    ''' utility functions '''
+    
+    def _get_headers(self):
+        headers = {
+            'Authentication': self.authentication_key,
+            'Accept': 'application/json',
+            'Version': '2.2'}
+        return headers
+    
+    ''' api methods '''
+    
+    def tonalize_multiple(self, articles, options = None):
+        '''
+        tonalize multiple articles
+        
+        Args:
+                -articles: articles to tonalize
+                -options: additional parameters (reference_ids and return_fields)
+                
+        Returns:
+                -see the api documentation for the format of this object
+        '''
+        if articles == None or len(articles) == 0:
+            raise Exception('You must include articles to tonalize')
+    
+        url = self.API_BASE + self.TONALIZE_MULTIPLE
+        data = {'articles': articles}
+        if options != None: data.update(options)
+        for key, value in data.iteritems(): data[key] = json.dumps(value)
+        data = urllib.urlencode(data)
+        
+        headers = self._get_headers()
+        request = urllib2.Request(url, data, headers)
+        response = urllib2.urlopen(request)
+        return json.loads(response.read())
 
-  def tonalize_detailed(self, article, options = None):
-    '''
-    tonalize an article
-    
-    Args:
-        -article: article to tonalize
-        -options: additional parameters (reference_id and return_fields)
+    def tonalize_detailed(self, article, options = None):
+        '''
+        tonalize an article
         
-    Returns:
-        -see the api documentation for the format of this object
-    '''
-    if article == None or len(article) == 0:
-      raise Exception('You must include an article to tonalize')
-  
-    url = self.API_BASE + self.TONALIZE_DETAILED
-    data = {'article': article}
-    if options != None: data.update(options)
-    for key, value in data.iteritems(): data[key] = json.dumps(value)
-    data = urllib.urlencode(data)
-  
-    headers = self._get_headers()
-    request = urllib2.Request(url, data, headers)
-    response = urllib2.urlopen(request)
-    return json.loads(response.read())
-  
-  def tonalize(self, article, options = None):
-    '''
-    tonalize an article
+        Args:
+                -article: article to tonalize
+                -options: additional parameters (reference_id and return_fields)
+                
+        Returns:
+                -see the api documentation for the format of this object
+        '''
+        if article == None or len(article) == 0:
+            raise Exception('You must include an article to tonalize')
     
-    Args:
-        -article: article to tonalize
-        -options: additional parameters (reference_id and return_fields)
+        url = self.API_BASE + self.TONALIZE_DETAILED
+        data = {'article': article}
+        if options != None: data.update(options)
+        for key, value in data.iteritems(): data[key] = json.dumps(value)
+        data = urllib.urlencode(data)
+    
+        headers = self._get_headers()
+        request = urllib2.Request(url, data, headers)
+        response = urllib2.urlopen(request)
+        return json.loads(response.read())
+    
+    def tonalize(self, article, options = None):
+        '''
+        tonalize an article
         
-    Returns:
-        -see the api documentation for the format of this object
-    '''
-    if article == None or len(article) == 0:
-      raise Exception('You must include an article to tonalize')
-  
-    url = self.API_BASE + self.TONALIZE
-    data = {'article': article}
-    if options != None: data.update(options)
-    for key, value in data.iteritems(): data[key] = json.dumps(value)
-    data = urllib.urlencode(data)
-  
-    headers = self._get_headers()
-    request = urllib2.Request(url, data, headers)
-    response = urllib2.urlopen(request)
-    return json.loads(response.read())
+        Args:
+                -article: article to tonalize
+                -options: additional parameters (reference_id and return_fields)
+                
+        Returns:
+                -see the api documentation for the format of this object
+        '''
+        if article == None or len(article) == 0:
+            raise Exception('You must include an article to tonalize')
+    
+        url = self.API_BASE + self.TONALIZE
+        data = {'article': article}
+        if options != None: data.update(options)
+        for key, value in data.iteritems(): data[key] = json.dumps(value)
+        data = urllib.urlencode(data)
+    
+        headers = self._get_headers()
+        request = urllib2.Request(url, data, headers)
+        response = urllib2.urlopen(request)
+        return json.loads(response.read())
 
-  def flag_response(self, phrase, api_method = None, api_version = '2.2', callback_url = None, options = None):
-    '''
-    flag a response as inaccurate
-    
-    Args:
-        -phrase: the phrase that returns an inaccurate response
-        -api_method: the method that returns an inaccurate response
-        -api_version: the version that returns an inaccurate response
-        -callback_url: a url to call when the phrase has been re-rated
-        -options: additional parameters (reference_id)
+    def flag_response(self, phrase, api_method = None, api_version = '2.2', callback_url = None, options = None):
+        '''
+        flag a response as inaccurate
         
-    Returns:
-        -see the api documentation for the format of this object
-    '''
-    if phrase == None or len(phrase) == 0:
-      raise Exception('You must include a phrase to flag')
-  
-    url = self.API_BASE + self.FLAG_RESPONSE
-    data = {'phrase': phrase}
-  
-    if (api_method != None): data['apiMethod'] = api_method
-    if (api_version != None): data['apiVersion'] = api_version
-    if (callback_url != None): data['callbackUrl'] = callback_url
-    if (options != None): data.update(options)
-  
-    for key, value in data.iteritems(): data[key] = json.dumps(value)
-    data = urllib.urlencode(data)
-  
-    headers = self._get_headers()
-    request = urllib2.Request(url, data, headers)
-    response = urllib2.urlopen(request)
-    return response.read()
+        Args:
+                -phrase: the phrase that returns an inaccurate response
+                -api_method: the method that returns an inaccurate response
+                -api_version: the version that returns an inaccurate response
+                -callback_url: a url to call when the phrase has been re-rated
+                -options: additional parameters (reference_id)
+                
+        Returns:
+                -see the api documentation for the format of this object
+        '''
+        if phrase == None or len(phrase) == 0:
+            raise Exception('You must include a phrase to flag')
+    
+        url = self.API_BASE + self.FLAG_RESPONSE
+        data = {'phrase': phrase}
+    
+        if (api_method != None): data['apiMethod'] = api_method
+        if (api_version != None): data['apiVersion'] = api_version
+        if (callback_url != None): data['callbackUrl'] = callback_url
+        if (options != None): data.update(options)
+    
+        for key, value in data.iteritems(): data[key] = json.dumps(value)
+        data = urllib.urlencode(data)
+    
+        headers = self._get_headers()
+        request = urllib2.Request(url, data, headers)
+        response = urllib2.urlopen(request)
+        return response.read()

--- a/lymbix.py
+++ b/lymbix.py
@@ -2,13 +2,14 @@ import urllib
 import urllib2
 import json
 
+
 class Lymbix:
-    
-    API_BASE = 'https://gyrus.lymbix.com/';
-    TONALIZE_MULTIPLE = 'tonalize_multiple';
-    TONALIZE_DETAILED = 'tonalize_detailed';
-    TONALIZE = 'tonalize';
-    FLAG_RESPONSE = 'flag_response';
+
+    API_BASE = 'https://gyrus.lymbix.com/'
+    TONALIZE_MULTIPLE = 'tonalize_multiple'
+    TONALIZE_DETAILED = 'tonalize_detailed'
+    TONALIZE = 'tonalize'
+    FLAG_RESPONSE = 'flag_response'
 
     def __init__(self, authentication_key):
         '''
@@ -17,123 +18,123 @@ class Lymbix:
         '''
         if authentication_key == None or len(authentication_key) == 0:
             raise Exception('You must include your authentication key')
-        
+
         self.authentication_key = authentication_key
-    
+
     ''' utility functions '''
-    
+
     def _get_headers(self):
         headers = {
             'Authentication': self.authentication_key,
             'Accept': 'application/json',
             'Version': '2.2'}
         return headers
-    
+
     ''' api methods '''
-    
-    def tonalize_multiple(self, articles, options = None):
+
+    def tonalize_multiple(self, articles, options=None):
         '''
         tonalize multiple articles
-        
+
         Args:
                 -articles: articles to tonalize
                 -options: additional parameters (reference_ids and return_fields)
-                
+
         Returns:
                 -see the api documentation for the format of this object
         '''
         if articles == None or len(articles) == 0:
             raise Exception('You must include articles to tonalize')
-    
+
         url = self.API_BASE + self.TONALIZE_MULTIPLE
         data = {'articles': articles}
         if options != None: data.update(options)
         for key, value in data.iteritems(): data[key] = json.dumps(value)
         data = urllib.urlencode(data)
-        
+
         headers = self._get_headers()
         request = urllib2.Request(url, data, headers)
         response = urllib2.urlopen(request)
         return json.loads(response.read())
 
-    def tonalize_detailed(self, article, options = None):
+    def tonalize_detailed(self, article, options=None):
         '''
         tonalize an article
-        
+
         Args:
                 -article: article to tonalize
                 -options: additional parameters (reference_id and return_fields)
-                
+
         Returns:
                 -see the api documentation for the format of this object
         '''
         if article == None or len(article) == 0:
             raise Exception('You must include an article to tonalize')
-    
+
         url = self.API_BASE + self.TONALIZE_DETAILED
         data = {'article': article}
         if options != None: data.update(options)
         for key, value in data.iteritems(): data[key] = json.dumps(value)
         data = urllib.urlencode(data)
-    
-        headers = self._get_headers()
-        request = urllib2.Request(url, data, headers)
-        response = urllib2.urlopen(request)
-        return json.loads(response.read())
-    
-    def tonalize(self, article, options = None):
-        '''
-        tonalize an article
-        
-        Args:
-                -article: article to tonalize
-                -options: additional parameters (reference_id and return_fields)
-                
-        Returns:
-                -see the api documentation for the format of this object
-        '''
-        if article == None or len(article) == 0:
-            raise Exception('You must include an article to tonalize')
-    
-        url = self.API_BASE + self.TONALIZE
-        data = {'article': article}
-        if options != None: data.update(options)
-        for key, value in data.iteritems(): data[key] = json.dumps(value)
-        data = urllib.urlencode(data)
-    
+
         headers = self._get_headers()
         request = urllib2.Request(url, data, headers)
         response = urllib2.urlopen(request)
         return json.loads(response.read())
 
-    def flag_response(self, phrase, api_method = None, api_version = '2.2', callback_url = None, options = None):
+    def tonalize(self, article, options=None):
+        '''
+        tonalize an article
+
+        Args:
+                -article: article to tonalize
+                -options: additional parameters (reference_id and return_fields)
+
+        Returns:
+                -see the api documentation for the format of this object
+        '''
+        if article == None or len(article) == 0:
+            raise Exception('You must include an article to tonalize')
+
+        url = self.API_BASE + self.TONALIZE
+        data = {'article': article}
+        if options != None: data.update(options)
+        for key, value in data.iteritems(): data[key] = json.dumps(value)
+        data = urllib.urlencode(data)
+
+        headers = self._get_headers()
+        request = urllib2.Request(url, data, headers)
+        response = urllib2.urlopen(request)
+        return json.loads(response.read())
+
+    def flag_response(self, phrase, api_method=None, api_version='2.2', callback_url=None, options=None):
         '''
         flag a response as inaccurate
-        
+
         Args:
                 -phrase: the phrase that returns an inaccurate response
                 -api_method: the method that returns an inaccurate response
                 -api_version: the version that returns an inaccurate response
                 -callback_url: a url to call when the phrase has been re-rated
                 -options: additional parameters (reference_id)
-                
+
         Returns:
                 -see the api documentation for the format of this object
         '''
         if phrase == None or len(phrase) == 0:
             raise Exception('You must include a phrase to flag')
-    
+
         url = self.API_BASE + self.FLAG_RESPONSE
         data = {'phrase': phrase}
-    
+
         if (api_method != None): data['apiMethod'] = api_method
         if (api_version != None): data['apiVersion'] = api_version
         if (callback_url != None): data['callbackUrl'] = callback_url
         if (options != None): data.update(options)
-    
+
         for key, value in data.iteritems(): data[key] = json.dumps(value)
         data = urllib.urlencode(data)
-    
+
         headers = self._get_headers()
         request = urllib2.Request(url, data, headers)
         response = urllib2.urlopen(request)

--- a/lymbix.py
+++ b/lymbix.py
@@ -30,6 +30,13 @@ class Lymbix:
             'Version': '2.2'}
         return headers
 
+    def _prep_data(self, data, options):
+        if options:
+            data.update(options)
+        for key, value in data.iteritems():
+            data[key] = json.dumps(value)
+        return urllib.urlencode(data)
+
     ''' api methods '''
 
     def tonalize_multiple(self, articles, options=None):
@@ -48,9 +55,7 @@ class Lymbix:
 
         url = self.API_BASE + self.TONALIZE_MULTIPLE
         data = {'articles': articles}
-        if options is not None: data.update(options)
-        for key, value in data.iteritems(): data[key] = json.dumps(value)
-        data = urllib.urlencode(data)
+        data = self._prep_data(data, options)
 
         headers = self._get_headers()
         request = urllib2.Request(url, data, headers)
@@ -72,10 +77,9 @@ class Lymbix:
             raise Exception('You must include an article to tonalize')
 
         url = self.API_BASE + self.TONALIZE_DETAILED
+
         data = {'article': article}
-        if options is not None: data.update(options)
-        for key, value in data.iteritems(): data[key] = json.dumps(value)
-        data = urllib.urlencode(data)
+        data = self._prep_data(data, options)
 
         headers = self._get_headers()
         request = urllib2.Request(url, data, headers)
@@ -98,9 +102,7 @@ class Lymbix:
 
         url = self.API_BASE + self.TONALIZE
         data = {'article': article}
-        if options is not None: data.update(options)
-        for key, value in data.iteritems(): data[key] = json.dumps(value)
-        data = urllib.urlencode(data)
+        data = self._prep_data(data, options)
 
         headers = self._get_headers()
         request = urllib2.Request(url, data, headers)
@@ -125,15 +127,15 @@ class Lymbix:
             raise Exception('You must include a phrase to flag')
 
         url = self.API_BASE + self.FLAG_RESPONSE
+
         data = {'phrase': phrase}
-
-        if (api_method is not None): data['apiMethod'] = api_method
-        if (api_version is not None): data['apiVersion'] = api_version
-        if (callback_url is not None): data['callbackUrl'] = callback_url
-        if (options is not None): data.update(options)
-
-        for key, value in data.iteritems(): data[key] = json.dumps(value)
-        data = urllib.urlencode(data)
+        if (api_method is not None):
+            data['apiMethod'] = api_method
+        if (api_version is not None):
+            data['apiVersion'] = api_version
+        if (callback_url is not None):
+            data['callbackUrl'] = callback_url
+        data = self._prep_data(data, options)
 
         headers = self._get_headers()
         request = urllib2.Request(url, data, headers)

--- a/lymbix.py
+++ b/lymbix.py
@@ -16,7 +16,7 @@ class Lymbix:
         Args:
                 -authentication_key: your Lymbix authentication key
         '''
-        if authentication_key == None or len(authentication_key) == 0:
+        if authentication_key is None or len(authentication_key) == 0:
             raise Exception('You must include your authentication key')
 
         self.authentication_key = authentication_key
@@ -43,12 +43,12 @@ class Lymbix:
         Returns:
                 -see the api documentation for the format of this object
         '''
-        if articles == None or len(articles) == 0:
+        if articles is None or len(articles) == 0:
             raise Exception('You must include articles to tonalize')
 
         url = self.API_BASE + self.TONALIZE_MULTIPLE
         data = {'articles': articles}
-        if options != None: data.update(options)
+        if options is not None: data.update(options)
         for key, value in data.iteritems(): data[key] = json.dumps(value)
         data = urllib.urlencode(data)
 
@@ -68,12 +68,12 @@ class Lymbix:
         Returns:
                 -see the api documentation for the format of this object
         '''
-        if article == None or len(article) == 0:
+        if article is None or len(article) == 0:
             raise Exception('You must include an article to tonalize')
 
         url = self.API_BASE + self.TONALIZE_DETAILED
         data = {'article': article}
-        if options != None: data.update(options)
+        if options is not None: data.update(options)
         for key, value in data.iteritems(): data[key] = json.dumps(value)
         data = urllib.urlencode(data)
 
@@ -93,12 +93,12 @@ class Lymbix:
         Returns:
                 -see the api documentation for the format of this object
         '''
-        if article == None or len(article) == 0:
+        if article is None or len(article) == 0:
             raise Exception('You must include an article to tonalize')
 
         url = self.API_BASE + self.TONALIZE
         data = {'article': article}
-        if options != None: data.update(options)
+        if options is not None: data.update(options)
         for key, value in data.iteritems(): data[key] = json.dumps(value)
         data = urllib.urlencode(data)
 
@@ -121,16 +121,16 @@ class Lymbix:
         Returns:
                 -see the api documentation for the format of this object
         '''
-        if phrase == None or len(phrase) == 0:
+        if phrase is None or len(phrase) == 0:
             raise Exception('You must include a phrase to flag')
 
         url = self.API_BASE + self.FLAG_RESPONSE
         data = {'phrase': phrase}
 
-        if (api_method != None): data['apiMethod'] = api_method
-        if (api_version != None): data['apiVersion'] = api_version
-        if (callback_url != None): data['callbackUrl'] = callback_url
-        if (options != None): data.update(options)
+        if (api_method is not None): data['apiMethod'] = api_method
+        if (api_version is not None): data['apiVersion'] = api_version
+        if (callback_url is not None): data['callbackUrl'] = callback_url
+        if (options is not None): data.update(options)
 
         for key, value in data.iteritems(): data[key] = json.dumps(value)
         data = urllib.urlencode(data)

--- a/lymbix.py
+++ b/lymbix.py
@@ -5,7 +5,7 @@ import json
 
 class Lymbix:
 
-    API_BASE = 'https://gyrus.lymbix.com/'
+    API_BASE = 'https://api.lymbix.com/'
     TONALIZE_MULTIPLE = 'tonalize_multiple'
     TONALIZE_DETAILED = 'tonalize_detailed'
     TONALIZE = 'tonalize'

--- a/lymbix.py
+++ b/lymbix.py
@@ -16,7 +16,7 @@ class Lymbix:
         Args:
                 -authentication_key: your Lymbix authentication key
         '''
-        if authentication_key is None or len(authentication_key) == 0:
+        if not authentication_key:
             raise Exception('You must include your authentication key')
 
         self.authentication_key = authentication_key
@@ -58,7 +58,7 @@ class Lymbix:
         Returns:
                 -see the api documentation for the format of this object
         '''
-        if articles is None or len(articles) == 0:
+        if not articles:
             raise Exception('You must include articles to tonalize')
 
         url = self.API_BASE + self.TONALIZE_MULTIPLE
@@ -78,7 +78,7 @@ class Lymbix:
         Returns:
                 -see the api documentation for the format of this object
         '''
-        if article is None or len(article) == 0:
+        if not article:
             raise Exception('You must include an article to tonalize')
 
         url = self.API_BASE + self.TONALIZE_DETAILED
@@ -99,7 +99,7 @@ class Lymbix:
         Returns:
                 -see the api documentation for the format of this object
         '''
-        if article is None or len(article) == 0:
+        if not article:
             raise Exception('You must include an article to tonalize')
 
         url = self.API_BASE + self.TONALIZE
@@ -122,7 +122,7 @@ class Lymbix:
         Returns:
                 -see the api documentation for the format of this object
         '''
-        if phrase is None or len(phrase) == 0:
+        if not phrase:
             raise Exception('You must include a phrase to flag')
 
         url = self.API_BASE + self.FLAG_RESPONSE

--- a/lymbix.py
+++ b/lymbix.py
@@ -37,6 +37,14 @@ class Lymbix:
             data[key] = json.dumps(value)
         return urllib.urlencode(data)
 
+    def _call(self, url, data, json=False):
+        headers = self._get_headers()
+        request = urllib2.Request(url, data, headers)
+        response = urllib2.urlopen(request)
+        if json:
+            return json.loads(response.read())
+        return response.read()
+
     ''' api methods '''
 
     def tonalize_multiple(self, articles, options=None):
@@ -57,10 +65,7 @@ class Lymbix:
         data = {'articles': articles}
         data = self._prep_data(data, options)
 
-        headers = self._get_headers()
-        request = urllib2.Request(url, data, headers)
-        response = urllib2.urlopen(request)
-        return json.loads(response.read())
+        return self._call(url, data, json=True)
 
     def tonalize_detailed(self, article, options=None):
         '''
@@ -81,10 +86,7 @@ class Lymbix:
         data = {'article': article}
         data = self._prep_data(data, options)
 
-        headers = self._get_headers()
-        request = urllib2.Request(url, data, headers)
-        response = urllib2.urlopen(request)
-        return json.loads(response.read())
+        return self._call(url, data, json=True)
 
     def tonalize(self, article, options=None):
         '''
@@ -104,10 +106,7 @@ class Lymbix:
         data = {'article': article}
         data = self._prep_data(data, options)
 
-        headers = self._get_headers()
-        request = urllib2.Request(url, data, headers)
-        response = urllib2.urlopen(request)
-        return json.loads(response.read())
+        return self._call(url, data, json=True)
 
     def flag_response(self, phrase, api_method=None, api_version='2.2', callback_url=None, options=None):
         '''
@@ -137,7 +136,4 @@ class Lymbix:
             data['callbackUrl'] = callback_url
         data = self._prep_data(data, options)
 
-        headers = self._get_headers()
-        request = urllib2.Request(url, data, headers)
-        response = urllib2.urlopen(request)
-        return response.read()
+        return self._call(url, data)


### PR DESCRIPTION
Lymbix's python client had an outdated hostname for the API server, so when their certificate expired on the old hostname, our requests started getting killed.

This updates that hostname, and also does a little cleanup in the library for PEP/DRY purposes. It doesn't intend to change any functionality aside from the updated hostname.

For internal review @rvause 
